### PR TITLE
[EGRC-178] GET Operations for SSPs

### DIFF
--- a/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -20,11 +20,11 @@ public class SspController {
 
   private RestTemplate restTemplate = new RestTemplate();
 
-  private static final String SSP_URL_80053r5 = "https://raw.githubusercontent.com/usnistgov/oscal-content/master/examples/ssp/json/ssp-example.json";
+  private static final String SSP_EXAMPLE_URL = "https://raw.githubusercontent.com/usnistgov/oscal-content/master/examples/ssp/json/ssp-example.json";
 
-  public static final String SSP_ID_80053r5 = "66c2a1c8-5830-48bd-8fdd-55a1c3a52888";
+  public static final String SSP_EXAMPLE_ID = "66c2a1c8-5830-48bd-8fdd-55a1c3a52888";
 
-  private String sspFromUrl = restTemplate.getForObject(SSP_URL_80053r5, String.class);
+  private String sspFromUrl = restTemplate.getForObject(SSP_EXAMPLE_URL, String.class);
 
   /**
    * Defines a GET request for ssp by ID.
@@ -36,7 +36,7 @@ public class SspController {
   @GetMapping("/ssps/{id}")
   public ResponseEntity<String> findById(@Parameter @PathVariable String id) {
 
-    if (id.contains(SSP_ID_80053r5)) {
+    if (id.contains(SSP_EXAMPLE_ID)) {
       return new ResponseEntity<String>(sspFromUrl, HttpStatus.OK);
     } else {
       return new ResponseEntity<String>("Ssp not found", HttpStatus.NOT_FOUND);

--- a/src/test/java/com/easydynamics/oscalrestservice/SspControllerTests.java
+++ b/src/test/java/com/easydynamics/oscalrestservice/SspControllerTests.java
@@ -1,5 +1,5 @@
 package com.easydynamics.oscalrestservice;
-import static com.easydynamics.oscalrestservice.api.SspController.SSP_ID_80053r5;
+import static com.easydynamics.oscalrestservice.api.SspController.SSP_EXAMPLE_ID;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import org.junit.jupiter.api.Test;
@@ -22,7 +22,7 @@ public class SspControllerTests {
 
   @Test
   public void shouldReturnDefaultMessage() throws Exception {
-    this.mockMvc.perform(get("/oscal/v1/ssps/{id}", SSP_ID_80053r5))
+    this.mockMvc.perform(get("/oscal/v1/ssps/{id}", SSP_EXAMPLE_ID))
         .andExpect(status().isOk());
   }
 


### PR DESCRIPTION
## Functionality
`http://localhost:8080/oscal/v1/ssps/66c2a1c8-5830-48bd-8fdd-55a1c3a52888` returns the ssp-example.json from the oscal-content github repo.

`mvn test` to run the SspController tests

http://localhost:8080/swagger-ui/index.html displays Swagger UI, with functionality for the ssps/{id} endpoint.
* Make sure to set the server to `http`, it is `https` by default on the Swagger UI