### PR TITLE
Fix GitHub Actions to publish to GitHub Maven Registry

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -1,7 +1,7 @@
 name: Publish package to GitHub Packages
 on:
   push:
-    branches: [EGRC-492]
+    branches: [develop]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Moved the GitHub actions config into the proper workflow directory.
Set the actions to trigger on push to the feature branch for
testing purposes; this must be changed back to `develop` before merging.