### PR TITLE
Update rest service package on push to develop

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -1,7 +1,7 @@
 name: Publish package to GitHub Packages
 on:
   push:
-    branches: [update-package-workflow]
+    branches: [develop]
   workflow_dispatch:
 
 jobs:
@@ -11,6 +11,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Delete previous oscal-rest-service version
+        uses: actions/delete-package-versions@v1
+        with:
+          package-name: com.easydynamics.oscal-rest-service
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup Java


### PR DESCRIPTION
On a push to develop, we want to update the repository package. Currently, `mvn deploy` will publish the package with the existing version, resulting in multiple .jar (and other) files published as part of the same release version. To get around this, we delete the current version of the package and publish again without changing the version number.