### PR TITLE
Automate Replacement of UUIDs

### DIFF
--- a/oscal-tools/replace-uuids.sh
+++ b/oscal-tools/replace-uuids.sh
@@ -19,7 +19,7 @@ while read -r line; do
   uuid="$(sed 's/^.*"uuid":"\(.*\)"/\1/g' <<< "$line")" #Extracting the uuid
 
   #Checking if we have already found the current value of uuid in the file
-  if [[ ! $(echo "${uuid_array[@]}" | grep --quiet --only-matching "$uuid") ]]; then	
+  if ! echo "${uuid_array[@]}" | grep --quiet --only-matching "$uuid"; then	
     #adding the uuid (in the current line) to the array of replaced uuids
     uuid_array+=("$uuid")
 


### PR DESCRIPTION
Create a script that takes in any json file (though it's intended primarily for OSCAL documents) and replaces all uuids in the file with an autogenerated uuid using the `uuidgen` command. If there are multiple instances of a given uuid in the file, all duplicate instances of that uuid will be replaced with the same autogenerated uuid.

To run the script, navigate to the `oscal-tools` directory and run the following command:
>bash replace-uuids.sh -oscalfile:$FILE

where $FILE is the path to the OSCAL file on which you want to regenerate uuids.