### PR TITLE
Fix CORS on preflight requests

### DIFF
--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/OscalRestServiceApplication.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/OscalRestServiceApplication.java
@@ -36,7 +36,7 @@ public class OscalRestServiceApplication {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
         String urls = env.getProperty(PROPERTY_CORS_ALLOWED_ORIGINS);
-        registry.addMapping("/oscal/v1/**").allowedOrigins(urls.split(","));
+        registry.addMapping("/oscal/v1/**").allowedOrigins(urls.split(",")).allowedMethods("*");
       }
     };
   }


### PR DESCRIPTION
Previously, the `OPTIONS` endpoint was not allowed which would result in
a 403 reponse to a preflight request. The 403 error response (and in
fact, error responses in general) does not contain an
`Access-Control-Allow-Origin` headers. Because of this, the preflight
would fail and the browser would not send the actual request. This
allows all request methods ("*"). Looking into the reponses, it seems
that only methods that have an implementation are defined (so for
example, most things *as of right now* do not have PUT).
