### PR TITLE
Add License and links to contributing docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2022 Easy Dynamics Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ You can view the api documentation in swagger-ui by pointing to
 http://localhost:8080/swagger-ui/index.html
 
 Change default port value in application.properties
+
+## Contributing
+
+For the process of Contributing to the project, please review
+[CONTRIBUTING.md](https://github.com/EasyDynamics/.github/CONTRIBUTING.md)
+and adhere to the
+[Code of Conduct](https://github.com/EasyDynamics/.github/CODE_OF_CONDUCT.md).
+
+## Licensing
+
+For information on the project's license, please review the [LICENSE](/LICENSE) file.
+


### PR DESCRIPTION
The MIT license is selected since the repository is primarily code and
it matches the license for the oscal-react-library repository.

The issue of what license to apply to the `oscal-content` test/sample content
is not specifically addressed as part of this. We've talked about
separating that into its own repository licensed separately (and that work is
in progress). I think rolling with MIT at the top-level might be sufficient
for now?