### PR TITLE
Add more complicated version checks

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,6 +1,7 @@
 name: Run tests
 on:
   pull_request:
+  push:
     branches:
       - develop
       - main
@@ -9,17 +10,27 @@ jobs:
   test:
     strategy:
       matrix:
-        java: [11, 17]
+        java:
+          # We need to test both the version of javac itself (well, technically the version of
+          # the JDK providing `javax.tools.JavaCompiler`), below called `actual` and the version
+          # passed to the `--release` flag, below called `target`. We check the two most recent
+          # LTS releases and the latest stable release. We check that both LTSes can target
+          # themselves and the oldest supported LTS, and that the latest stable release can
+          # target itself. We do not test against EA builds.
+          - { actual: 11, target: 11 } # Oldest supported LTS
+          - { actual: 17, target: 17 } # Latest LTS
+          - { actual: 17, target: 11 } # Latest LTS, targeting the oldest
+          - { actual: 18, target: 18 } # Latest stable release
     runs-on: ubuntu-latest
-    name: "Build and test on Java ${{ matrix.java }}"
+    name: "Build and test on Java ${{ matrix.java.actual }} targeting ${{ matrix.java.target }}"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Java
         uses: actions/setup-java@v2
         with:
-          java-version: "${{ matrix.java }}"
+          java-version: "${{ matrix.java.actual }}"
           distribution: 'temurin'
           cache: 'maven'
       - name: Build and test
-        run: mvn package
+        run: mvn -Djava.version=${{ matrix.java.target }} clean package

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,6 @@
 	<description>Initial OSCAL REST API Parent</description>
 	<properties>
 		<java.version>11</java.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<validation-api.version>2.0.1.Final</validation-api.version>
 		<spring-boot-starter-data-jpa.version>2.6.5</spring-boot-starter-data-jpa.version>
 		<spring-core.version>5.3.17</spring-core.version>
@@ -19,6 +17,7 @@
 		<junit.version>5.8.2</junit.version>
 		<maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 	<distributionManagement>
@@ -40,27 +39,36 @@
 	<build>
 		<plugins>
 			<plugin>
-				 <groupId>org.apache.maven.plugins</groupId>
-				 <artifactId>maven-checkstyle-plugin</artifactId>
-				 <version>${maven-checkstyle-plugin.version}</version>
-				 <configuration>
-					 <configLocation>google_checks.xml</configLocation>
-					 <encoding>UTF-8</encoding>
-					 <consoleOutput>true</consoleOutput>
-					 <failsOnError>true</failsOnError>
-					 <violationSeverity>warning</violationSeverity>
-					 <linkXRef>false</linkXRef>
-				 </configuration>
-				 <executions>
-					 <execution>
-						 <id>validate</id>
-						 <phase>validate</phase>
-						 <goals>
-							 <goal>check</goal>
-						 </goals>
-					 </execution>
-				 </executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven-checkstyle-plugin.version}</version>
+				<configuration>
+					<configLocation>google_checks.xml</configLocation>
+					<encoding>UTF-8</encoding>
+					<consoleOutput>true</consoleOutput>
+					<failsOnError>true</failsOnError>
+					<violationSeverity>warning</violationSeverity>
+					<linkXRef>false</linkXRef>
+				</configuration>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven-compiler-plugin.version}</version>
+				<configuration>
+					<release>${java.version}</release>
+				</configuration>
+			</plugin>
+
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven-surefire-plugin.version}</version>


### PR DESCRIPTION
This adds a more comprehensive matrix of supported versions, since
theoretically, an end user may be using Java 17 and trying to target
Java 11 or may want to target Java 17.
