### PR TITLE
Properly set the Content-Type for resources

### DIFF
--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/ResourceController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/ResourceController.java
@@ -3,6 +3,10 @@ package com.easydynamics.oscalrestservice.api;
 import com.easydynamics.oscal.data.repository.ResourceContentRepo;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
@@ -11,14 +15,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 /**
- * Catalog Controller for OSCAL REST Service. This class handles all requests to the /catalogs
- * endpoint.
+ * Resource Controller for OSCAL Rest Service. This class handles all requests to the
+ * /resource-content endpoint to support fetching and storing supporting resources in OSCAL
+ * documents (such as images).
  */
 @RequestMapping(path = "/oscal/v1")
 @RestController
 public class ResourceController {
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private ResourceContentRepo repository;
 
@@ -30,22 +38,36 @@ public class ResourceController {
   }
 
   /**
-   * Defines a GET request for catalog by ID.
+   * Defines a GET request for resource content by ID.
    *
-   * @param id the catalog uuid
-   * @return the oscal-content catalog hosted on github
+   * @param id the resource ID
+   * @return the supporting resource
    * @throws IOException thrown if there is an issue determining content length
    */
   @GetMapping("/resource-content/{id}")
-  public ResponseEntity<Resource> findById(@Parameter @PathVariable String id) throws IOException {
+  public ResponseEntity<StreamingResponseBody> findById(
+      @Parameter @PathVariable String id) throws IOException {
     Resource resource = repository.findById(id)
         .orElseThrow(() -> new OscalObjectNotFoundException(id));
+    Path resourcePath = resource.getFile().toPath();
+
+    MediaType contentType = MediaType.parseMediaType(Files.probeContentType(resourcePath));
+    if (contentType == null) {
+      // Using application/octet-stream ensurres that the resulting data is at least treated
+      // as binary content.
+      contentType = MediaType.APPLICATION_OCTET_STREAM;
+      logger.debug("Failed to automatically determine content type for {}. Falling back to {}",
+          id, contentType);
+    }
+
+    StreamingResponseBody responseBody = (outputStream) -> {
+      Files.copy(resourcePath, outputStream);
+    };
 
     return ResponseEntity.ok()
-    //.headers(headers)
     .contentLength(resource.contentLength())
-    .contentType(MediaType.APPLICATION_OCTET_STREAM) // TODO - improve this
-    .body(resource);
+    .contentType(contentType)
+    .body(responseBody);
   }
 
 }

--- a/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/ResourceContentControllerTests.java
+++ b/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/ResourceContentControllerTests.java
@@ -17,10 +17,10 @@ import org.springframework.test.web.servlet.MvcResult;
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-public abstract class ResourceContentControllerTests {
+public class ResourceContentControllerTests {
 
   private static final String EXPECTED_NAME = "authz-boundary.png";
-  private static final String EXPECTED_TYPE = "application/octet-stream";
+  private static final String EXPECTED_TYPE = "image/png";
 
   @Autowired
   private MockMvc mockMvc;
@@ -34,8 +34,8 @@ public abstract class ResourceContentControllerTests {
   @Test
   public void testGetOscalObject() throws Exception {
     // With StreamingResponseBody this is async so we start the request here
-    MvcResult asyncResult = this.mockMvc.perform(get("/oscal/v1/resource-content"
-        + "/{id}", EXPECTED_NAME))
+    MvcResult asyncResult = this.mockMvc
+        .perform(get("/oscal/v1/resource-content/{id}", EXPECTED_NAME))
         .andExpect(request().asyncStarted())
         .andReturn();
 


### PR DESCRIPTION
This ensures that we make a best-effort attempt to set the Content-Type
header for response objects (at least, a little better than running with
Octet Stream for everything). Doing so requires using the
`probeContentType` method on `Files`. If that fails, then we still fall
back to an Octet Stream which is good for ensuring the output is treated
as binary data (which resources almost always are).

The tests also were not running for this route because the test class
was `abstract`. We now use a `StreamingResponseBody` for this route as
well for consistency in tests and implementation. Also, not doing that
resulted in other tests randomly failing. We can just use `Files.copy`
for this so that we don't have to deal with performing the transfer
ourselves manually.
