### PR TITLE
Ability to add and update SSP Impl Req

### DIFF
--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/IterableAssemblyClassBinding.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/IterableAssemblyClassBinding.java
@@ -4,12 +4,28 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.json.IJsonWritingContext;
 import gov.nist.secauto.metaschema.binding.model.DefaultAssemblyClassBinding;
+import gov.nist.secauto.oscal.lib.model.ImplementedRequirement;
 import java.io.IOException;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import org.apache.commons.collections4.map.HashedMap;
 
 /**
  * Extends DefaultAssemblyClassBinding to add writing of root items as an array.
  */
 public class IterableAssemblyClassBinding extends DefaultAssemblyClassBinding {
+
+  /**
+   * Map of objects that are not declared as root in liboscal-java,
+   * but we want to treat them as such.
+   */
+  private static final Map<Class<?>, QName> secondaryRootObjects;
+
+  static {
+    secondaryRootObjects = new HashedMap<>();
+    secondaryRootObjects.put(ImplementedRequirement.class,
+        new QName("implemented-requirement"));
+  }
 
   protected IterableAssemblyClassBinding(Class<?> clazz, IBindingContext bindingContext) {
     super(clazz, bindingContext);
@@ -48,4 +64,18 @@ public class IterableAssemblyClassBinding extends DefaultAssemblyClassBinding {
 
     writer.writeEndArray();
   }
+
+  @Override
+  public boolean isRoot() {
+    return (super.isRoot() || secondaryRootObjects.containsKey(getBoundClass()));
+  }
+
+  @Override
+  public QName getRootXmlQName() {
+    if (secondaryRootObjects.containsKey(getBoundClass())) {
+      return secondaryRootObjects.get(getBoundClass());
+    }
+    return super.getRootXmlQName();
+  }
+
 }

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/IterableAssemblyClassBinding.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/IterableAssemblyClassBinding.java
@@ -8,7 +8,6 @@ import gov.nist.secauto.oscal.lib.model.ImplementedRequirement;
 import java.io.IOException;
 import java.util.Map;
 import javax.xml.namespace.QName;
-import org.apache.commons.collections4.map.HashedMap;
 
 /**
  * Extends DefaultAssemblyClassBinding to add writing of root items as an array.
@@ -19,13 +18,9 @@ public class IterableAssemblyClassBinding extends DefaultAssemblyClassBinding {
    * Map of objects that are not declared as root in liboscal-java,
    * but we want to treat them as such.
    */
-  private static final Map<Class<?>, QName> secondaryRootObjects;
-
-  static {
-    secondaryRootObjects = new HashedMap<>();
-    secondaryRootObjects.put(ImplementedRequirement.class,
-        new QName("implemented-requirement"));
-  }
+  private static final Map<Class<?>, QName> secondaryRootObjects = Map.ofEntries(
+      Map.entry(ImplementedRequirement.class, new QName("implemented-requirement"))
+  );
 
   protected IterableAssemblyClassBinding(Class<?> clazz, IBindingContext bindingContext) {
     super(clazz, bindingContext);
@@ -72,10 +67,7 @@ public class IterableAssemblyClassBinding extends DefaultAssemblyClassBinding {
 
   @Override
   public QName getRootXmlQName() {
-    if (secondaryRootObjects.containsKey(getBoundClass())) {
-      return secondaryRootObjects.get(getBoundClass());
-    }
-    return super.getRootXmlQName();
+    return secondaryRootObjects.getOrDefault(getBoundClass(), super.getRootXmlQName());
   }
 
 }

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
@@ -7,8 +7,8 @@ import com.easydynamics.oscal.data.marshalling.OscalObjectMarshallingException;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.BindingException;
 import gov.nist.secauto.metaschema.binding.io.Feature;
-import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.binding.io.IDeserializer;
+import gov.nist.secauto.metaschema.binding.io.json.DefaultJsonDeserializer;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,7 +33,7 @@ public abstract class BaseOscalObjectMarshallerLiboscalImpl<T> implements OscalO
         IterableAssemblyClassBinding.createInstance(clazz, context);
     this.serializer = new IterableJsonSerializer<T>(context, classBinding);
     this.serializer.enableFeature(Feature.SERIALIZE_ROOT);
-    this.deserializer = context.newDeserializer(Format.JSON, clazz);
+    this.deserializer = new DefaultJsonDeserializer<T>(context, classBinding);
     this.deserializer.enableFeature(Feature.DESERIALIZE_ROOT);
   }
 

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/OscalSspImplReqMarshallerImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/OscalSspImplReqMarshallerImpl.java
@@ -1,0 +1,15 @@
+package com.easydynamics.oscal.data.marshalling.impl;
+
+import gov.nist.secauto.oscal.lib.model.ImplementedRequirement;
+
+/**
+ * OSCAL SSP Implemented Requirement marshaller implementation.
+ */
+public class OscalSspImplReqMarshallerImpl
+    extends BaseOscalObjectMarshallerLiboscalImpl<ImplementedRequirement> {
+
+  public OscalSspImplReqMarshallerImpl() {
+    super(ImplementedRequirement.class);
+  }
+
+}

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/ServiceConfig.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/ServiceConfig.java
@@ -4,9 +4,11 @@ import com.easydynamics.oscal.data.marshalling.OscalObjectMarshaller;
 import com.easydynamics.oscal.data.marshalling.impl.OscalCatalogMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalComponentMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalProfileMarshallerImpl;
+import com.easydynamics.oscal.data.marshalling.impl.OscalSspImplReqMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalSspMarshallerImpl;
 import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.model.ComponentDefinition;
+import gov.nist.secauto.oscal.lib.model.ImplementedRequirement;
 import gov.nist.secauto.oscal.lib.model.Profile;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
 import org.springframework.context.annotation.Bean;
@@ -38,5 +40,10 @@ public class ServiceConfig {
   @Bean
   public OscalObjectMarshaller<SystemSecurityPlan> sspMarshaller() {
     return new OscalSspMarshallerImpl();
+  }
+
+  @Bean
+  public OscalObjectMarshaller<ImplementedRequirement> sspImplReqMarshaller() {
+    return new OscalSspImplReqMarshallerImpl();
   }
 }

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/BaseOscalController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/BaseOscalController.java
@@ -21,8 +21,8 @@ public abstract class BaseOscalController<T> {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-  private final BaseOscalObjectService<T> oscalObjectService;
-  private final OscalObjectMarshaller<T> oscalObjectMarshaller;
+  protected final BaseOscalObjectService<T> oscalObjectService;
+  protected final OscalObjectMarshaller<T> oscalObjectMarshaller;
 
   protected BaseOscalController(
       BaseOscalObjectService<T> oscalObjectService,
@@ -114,21 +114,21 @@ public abstract class BaseOscalController<T> {
     return makeObjectResponse(oscalObjectService.save(incomingOscalObject));
   }
 
-  private ResponseEntity<StreamingResponseBody> makeIterableResponse(
+  protected ResponseEntity<StreamingResponseBody> makeIterableResponse(
       Iterable<T> oscalObjectCollection) {
     return makeResponse(
       (outputStream) -> oscalObjectMarshaller.toJson(oscalObjectCollection, outputStream),
-      oscalObjectCollection.getClass());  
+      oscalObjectCollection.getClass());
   }
 
-  private ResponseEntity<StreamingResponseBody> makeObjectResponse(T oscalObject) {
+  protected ResponseEntity<StreamingResponseBody> makeObjectResponse(T oscalObject) {
     return makeResponse(
       (outputStream) -> oscalObjectMarshaller.toJson(oscalObject, outputStream),
-      oscalObject.getClass());  
+      oscalObject.getClass());
   }
 
-  private ResponseEntity<StreamingResponseBody> makeResponse(
-      Consumer<OutputStream> marshallingTask, 
+  protected ResponseEntity<StreamingResponseBody> makeResponse(
+      Consumer<OutputStream> marshallingTask,
       Class<?> clazz) {
 
     StreamingResponseBody responseBody = outputStream -> {

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/OscalControllerExceptionAdvice.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/OscalControllerExceptionAdvice.java
@@ -22,7 +22,7 @@ public class OscalControllerExceptionAdvice {
 
   @ResponseBody
   @ExceptionHandler(OscalObjectConflictException.class)
-  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseStatus(HttpStatus.CONFLICT)
   String oscalObjectConflictHandler(OscalObjectConflictException exception) {
     return exception.getMessage();
   }

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -179,8 +179,8 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
     }
 
     logger.debug("SSP ImplementedRequiremnt updated, saving via service");
-
-    return makeObjectResponse(oscalObjectService.save(existingSsp));
+    oscalObjectService.save(existingSsp);
+    return makeObjectResponse(incomingImplReq, oscalSspImplReqtMarshaller);
   }
 
   /**

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -113,8 +113,7 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
     return incomingOscalObject;
   }
 
- /**
-  *
+  /**
   * Helper function to add a new Implemented Requirement to the list
   * of Implemented Requirements in a given SSP.
   *
@@ -123,20 +122,20 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
   *
   */
   private void addImplReqToList(
-    SystemSecurityPlan existingSsp,
-    ImplementedRequirement incomingImplReq
-  ){
-      ControlImplementation controlImplementation = existingSsp.getControlImplementation();
-      if (controlImplementation == null) {
-        controlImplementation = new ControlImplementation();
-        existingSsp.setControlImplementation(controlImplementation);
-      }
-      List<ImplementedRequirement> implReqs = controlImplementation.getImplementedRequirements();
-      if (implReqs == null) {
-        implReqs = new ArrayList<>();
-        controlImplementation.setImplementedRequirements(implReqs);
-      }
-      implReqs.add(incomingImplReq);
+      SystemSecurityPlan existingSsp,
+      ImplementedRequirement incomingImplReq
+  ) {
+    ControlImplementation controlImplementation = existingSsp.getControlImplementation();
+    if (controlImplementation == null) {
+      controlImplementation = new ControlImplementation();
+      existingSsp.setControlImplementation(controlImplementation);
+    }
+    List<ImplementedRequirement> implReqs = controlImplementation.getImplementedRequirements();
+    if (implReqs == null) {
+      implReqs = new ArrayList<>();
+      controlImplementation.setImplementedRequirements(implReqs);
+    }
+    implReqs.add(incomingImplReq);
   }
 
   /**
@@ -203,10 +202,10 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
 
     // Throw an exception if the Implemented Requirement alrady exists
     if (existingSsp.getControlImplementation() != null
-      && existingSsp.getControlImplementation().getImplementedRequirements() != null
+        && existingSsp.getControlImplementation().getImplementedRequirements() != null
         && existingSsp.getControlImplementation().getImplementedRequirements().stream()
-            .anyMatch(implReq -> incomingImplReq.getUuid().equals(implReq.getUuid()))){
-          throw new OscalObjectConflictException("Implented Requirement already exists");
+          .anyMatch(implReq -> incomingImplReq.getUuid().equals(implReq.getUuid()))) {
+      throw new OscalObjectConflictException("Implented Requirement already exists");
     }
     
     addImplReqToList(existingSsp, incomingImplReq);
@@ -221,7 +220,6 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
    * implemented requirements.
    *
    * @param id the SSP uuid
-   * @param implementedRequirementId the Implemented Requirement uuid
    * @param json the SSP contents
    */
   @PostMapping(value = "/system-security-plans/{id}/control-implementation/"

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -36,7 +36,7 @@ import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBo
 @RestController
 public class SspController extends BaseOscalController<SystemSecurityPlan> {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
-  private final OscalObjectMarshaller<ImplementedRequirement> oscalSspImplReqtMarshaller;
+  private final OscalObjectMarshaller<ImplementedRequirement> oscalSspImplReqMarshaller;
 
   @Autowired(required = true)
   public SspController(
@@ -45,7 +45,7 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
       OscalObjectMarshaller<ImplementedRequirement> oscalSspImplReqtMarshaller
   ) {
     super(sspService, marshaller);
-    this.oscalSspImplReqtMarshaller = oscalSspImplReqtMarshaller;
+    this.oscalSspImplReqMarshaller = oscalSspImplReqtMarshaller;
   }
 
   @GetMapping("/system-security-plans")
@@ -102,7 +102,7 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
    * @throws OscalObjectConflictException when the path ID does not match the body ID
    */
   protected ImplementedRequirement unmarshallImplReqAndValidateId(String id, String json) {
-    ImplementedRequirement incomingOscalObject = oscalSspImplReqtMarshaller.toObject(
+    ImplementedRequirement incomingOscalObject = oscalSspImplReqMarshaller.toObject(
         new ByteArrayInputStream(json.getBytes()));
 
     UUID incomingUuid = incomingOscalObject.getUuid();
@@ -180,11 +180,11 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
 
     logger.debug("SSP ImplementedRequiremnt updated, saving via service");
     oscalObjectService.save(existingSsp);
-    return makeObjectResponse(incomingImplReq, oscalSspImplReqtMarshaller);
+    return makeObjectResponse(incomingImplReq, oscalSspImplReqMarshaller);
   }
 
   /**
-   * Does the work of finding an existing SSP and adding the 
+   * Does the work of finding an existing SSP and adding the
    * new Implemented Requirement.
    *
    * @param id the SSP UUID
@@ -197,7 +197,7 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
     SystemSecurityPlan existingSsp = oscalObjectService.findById(id)
         .orElseThrow(() -> new OscalObjectNotFoundException(id));
 
-    ImplementedRequirement incomingImplReq = oscalSspImplReqtMarshaller.toObject(
+    ImplementedRequirement incomingImplReq = oscalSspImplReqMarshaller.toObject(
         new ByteArrayInputStream(json.getBytes()));
 
     // Throw an exception if the Implemented Requirement alrady exists
@@ -205,9 +205,9 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
         && existingSsp.getControlImplementation().getImplementedRequirements() != null
         && existingSsp.getControlImplementation().getImplementedRequirements().stream()
           .anyMatch(implReq -> incomingImplReq.getUuid().equals(implReq.getUuid()))) {
-      throw new OscalObjectConflictException("Implented Requirement already exists");
+      throw new OscalObjectConflictException("Implemented Requirement already exists");
     }
-    
+
     addImplReqToList(existingSsp, incomingImplReq);
 
     logger.debug("SSP ImplementedRequiremnt updated, saving via service");

--- a/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/BaseOscalControllerTests.java
+++ b/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/BaseOscalControllerTests.java
@@ -38,7 +38,7 @@ import net.minidev.json.JSONArray;
 public abstract class BaseOscalControllerTests {
 
   @Autowired
-  private MockMvc mockMvc;
+  protected MockMvc mockMvc;
 
   protected OscalObjectType oscalObjectType;
   protected ExampleContent exampleContent;
@@ -50,7 +50,7 @@ public abstract class BaseOscalControllerTests {
     originalFileContents = Files.readString(Paths.get(
         "target/oscal-demo-content-main",
         oscalObjectType.jsonField + "s",
-        exampleContent.fileName), 
+        exampleContent.fileName),
         Charset.forName("UTF-8"));
   }
 
@@ -59,9 +59,9 @@ public abstract class BaseOscalControllerTests {
     Files.writeString(Paths.get(
         "target/oscal-demo-content-main",
         oscalObjectType.jsonField + "s",
-        exampleContent.fileName), 
+        exampleContent.fileName),
         originalFileContents, Charset.forName("UTF-8"));
-  } 
+  }
 
   /**
    * Tests if the GET Request to /<oscalType>/{id} will retrieve a valid default <oscalType> object.
@@ -242,7 +242,7 @@ public abstract class BaseOscalControllerTests {
         .andExpect(jsonPath("$[0].*.uuid").value(exampleContent.uuid));
   }
 
-  @Test 
+  @Test
   public void testPutOscalObjectNotFound() throws Exception {
     String id = "0300753c-563b-4956-b6f6-3a68950a5279";
     this.mockMvc.perform(put("/oscal/v1/" + oscalObjectType.restPath + "/{id}", id)
@@ -253,7 +253,7 @@ public abstract class BaseOscalControllerTests {
       .andExpect(status().isNotFound());
   }
 
-  @Test 
+  @Test
   public void testPutOscalObjectUnsupportedMediaType() throws Exception {
     this.mockMvc.perform(put("/oscal/v1/" + oscalObjectType.restPath + "/{id}", exampleContent.uuid)
       .contentType(MediaType.APPLICATION_XML_VALUE)
@@ -263,7 +263,7 @@ public abstract class BaseOscalControllerTests {
       .andExpect(status().isUnsupportedMediaType());
   }
 
-  @Test 
+  @Test
   public void testPutMismatchOscalObject() throws Exception {
     String badId = "8A7D0A6D-024E-416A-956A-FDEB8816EEA1";
     this.mockMvc.perform(put("/oscal/v1/" + oscalObjectType.restPath + "/{id}", exampleContent.uuid)
@@ -271,12 +271,12 @@ public abstract class BaseOscalControllerTests {
       .accept(MediaType.APPLICATION_JSON)
       .characterEncoding("UTF-8")
       .content(generateOscalObject(oscalObjectType.jsonField, badId)))
-      .andExpect(status().isBadRequest())
+      .andExpect(status().isConflict())
       .andExpect(content().string(containsStringIgnoringCase(badId)))
       .andExpect(content().string(containsStringIgnoringCase(exampleContent.uuid)));
   }
 
-  @Test 
+  @Test
   public void testPutNullIdMismatchOscalObject() throws Exception {
     String badId = null;
     this.mockMvc.perform(put("/oscal/v1/" + oscalObjectType.restPath + "/{id}", exampleContent.uuid)
@@ -288,7 +288,7 @@ public abstract class BaseOscalControllerTests {
   }
 
 
-  @Test 
+  @Test
   public void testPutOscalObjectSuccess() throws Exception {
     this.mockMvc.perform(put("/oscal/v1/" + oscalObjectType.restPath + "/{id}", exampleContent.uuid)
       .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -310,7 +310,7 @@ public abstract class BaseOscalControllerTests {
       + "  }\n"
       + "}";
   }
-  
+
   class DateGreaterMatcher extends BaseMatcher<ZonedDateTime> {
     private ZonedDateTime floor;
     DateGreaterMatcher(ZonedDateTime floor) {

--- a/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/SspControllerTests.java
+++ b/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/SspControllerTests.java
@@ -22,6 +22,8 @@ import com.easydynamics.oscal.data.example.ExampleContent;
  */
 public class SspControllerTests extends BaseOscalControllerTests {
 
+  private static final String ADD_SSP_IMPL_REQ_URL =
+      "/oscal/v1/system-security-plans/{id}/control-implementation/implemented-requirements";
   private static final String UPDATE_SSP_IMPL_REQ_URL =
       "/oscal/v1/system-security-plans/{id}/control-implementation/implemented-requirements/{implementedRequirementId}";
   private static final String EXISTING_IMPL_REQ_UUID = "aaadb3ff-6ae8-4332-92db-211468c52af2";
@@ -128,9 +130,8 @@ public class SspControllerTests extends BaseOscalControllerTests {
         .andExpect(expectedStatus);
     } else if (httpMethod.equals(HttpMethod.POST)){
       this.mockMvc.perform(
-          post(UPDATE_SSP_IMPL_REQ_URL,
-              exampleContent.uuid,
-              implReqUuid)
+          post(ADD_SSP_IMPL_REQ_URL,
+              exampleContent.uuid)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .accept(MediaType.APPLICATION_JSON)
         .characterEncoding("UTF-8")

--- a/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/SspControllerTests.java
+++ b/oscal-rest-service-app/src/test/java/com/easydynamics/oscalrestservice/api/SspControllerTests.java
@@ -1,5 +1,20 @@
 package com.easydynamics.oscalrestservice.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
+
 import com.easydynamics.oscal.data.example.ExampleContent;
 
 /**
@@ -7,9 +22,218 @@ import com.easydynamics.oscal.data.example.ExampleContent;
  */
 public class SspControllerTests extends BaseOscalControllerTests {
 
+  private static final String UPDATE_SSP_IMPL_REQ_URL =
+      "/oscal/v1/system-security-plans/{id}/control-implementation/implemented-requirements/{implementedRequirementId}";
+  private static final String EXISTING_IMPL_REQ_UUID = "aaadb3ff-6ae8-4332-92db-211468c52af2";
+  private static final String EXISTING_CONTROL_ID = "au-1";
+  private static final String EXISTING_STATEMENT_ID = "au-1_smt.a";
+  private static final String EXISTING_COMPONENT_UUID = "795533ab-9427-4abe-820f-0b571bacfe6d";
+  private static final String EXISTING_PARAM_ID = "au-1_prm_1";
+  private static final String NEW_IMPL_REQ_UUID = UUID.randomUUID().toString();
+  private static final String NEW_CONTROL_ID = "some-control";
+  private static final String NEW_STATEMENT_ID = NEW_CONTROL_ID + "_smt";
+  private static final String NEW_COMPONENT_UUID = UUID.randomUUID().toString();
+  private static final String NEW_PARAM_ID = NEW_CONTROL_ID + "_prm_1";
+  private static final String EXPECTED_PARAM_VALUE = "Some Param Value";
+
+
   private SspControllerTests() {
     this.oscalObjectType = OscalObjectType.SSP;
     this.exampleContent = ExampleContent.SSP_EXAMPLE;
   }
 
+  /**
+   * Builds an SSP Implemented Requirement JSON string with the given
+   * values.
+   *
+   * @param implReqUuid
+   * @param controlId
+   * @param statementId
+   * @param componentUuid
+   * @param paramId
+   * @param paramValue
+   * @return the SSP Implemented Requirement JSON string
+   */
+  private String buildImplementedRequirementJson(
+      String implReqUuid,
+      String controlId,
+      String statementId,
+      String componentUuid,
+      String paramId,
+      String paramValue
+      ) {
+    return "{\n"
+        + "  \"implemented-requirement\": {\n"
+        + "    \"uuid\": \"" + implReqUuid + "\",\n"
+        + "    \"control-id\": \"" + controlId + "\",\n"
+        + "    \"statements\": [\n"
+        + "      {\n"
+        + "         \"statement-id\": \"" + statementId + "\",\n"
+        + "         \"by-components\": [\n"
+        + "           {\n"
+        + "             \"component-uuid\": \"" + componentUuid + "\",\n"
+        + "             \"set-parameters\": [\n"
+        + "               {\n"
+        + "                 \"param-id\": \"" + paramId + "\",\n"
+        + "                 \"values\": [ \"" + paramValue + "\" ]\n"
+        + "               }\n"
+        + "             ]\n"
+        + "           }\n"
+        + "         ]\n"
+        + "       }\n"
+        + "    ]\n"
+        + "  }\n"
+        + "}";
+  }
+
+  /**
+   * Does the work of actually performing the mock MVC request for
+   * updating an SSP Impl Req.
+   *
+   * @param httpMethod
+   * @param implReqUuid
+   * @param controlId
+   * @param statementId
+   * @param componentUuid
+   * @param paramId
+   * @param expectedParamValue
+   * @param expectedStatus
+   * @param isUpdateExpected
+   * @throws Exception
+   */
+  private void testSspImplReq(
+      HttpMethod httpMethod,
+      String implReqUuid,
+      String controlId,
+      String statementId,
+      String componentUuid,
+      String paramId,
+      String expectedParamValue,
+      ResultMatcher expectedStatus,
+      boolean isUpdateExpected
+      ) throws Exception {
+
+    String implReq = buildImplementedRequirementJson(
+        implReqUuid, controlId, statementId, componentUuid, paramId, expectedParamValue);
+
+    if (httpMethod.equals(HttpMethod.PUT)) {
+      this.mockMvc.perform(
+          put(UPDATE_SSP_IMPL_REQ_URL,
+              exampleContent.uuid,
+              implReqUuid)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON)
+        .characterEncoding("UTF-8")
+        .content(implReq))
+        .andExpect(expectedStatus);
+    } else if (httpMethod.equals(HttpMethod.POST)){
+      this.mockMvc.perform(
+          post(UPDATE_SSP_IMPL_REQ_URL,
+              exampleContent.uuid,
+              implReqUuid)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON)
+        .characterEncoding("UTF-8")
+        .content(implReq))
+        .andExpect(expectedStatus);
+    } else {
+      throw new UnsupportedOperationException();
+    }
+
+    // With StreamingResponseBody this is async so we start the request here
+    MvcResult asyncResult = this.mockMvc.perform(get("/oscal/v1/"
+        + oscalObjectType.restPath + "/{id}", exampleContent.uuid))
+        .andExpect(request().asyncStarted())
+        .andReturn();
+
+    if (isUpdateExpected) {
+      // On async result check the content and title
+      this.mockMvc.perform(asyncDispatch(asyncResult))
+          .andExpect(status().isOk())
+          .andExpect(content().contentType("application/json"))
+          .andExpect(jsonPath("$.*.control-implementation"
+              + ".implemented-requirements[?(@.uuid == \"" + implReqUuid + "\")]"
+              + ".statements[?(@.statement-id == \"" + statementId + "\")]"
+              + ".by-components[?(@.component-uuid == \"" + componentUuid + "\")]"
+              + ".set-parameters[?(@.param-id == \"" + paramId + "\")]"
+              + ".values[0]").value(expectedParamValue));
+    }
+  }
+
+  /**
+   * Tests if the request to add a new SSP Implemented Requirement updates the SSP via POST.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testCreateSspImplReqViaPost() throws Exception {
+    testSspImplReq(
+        HttpMethod.POST,
+        NEW_IMPL_REQ_UUID,
+        NEW_CONTROL_ID,
+        NEW_STATEMENT_ID,
+        NEW_COMPONENT_UUID,
+        NEW_PARAM_ID,
+        EXPECTED_PARAM_VALUE,
+        status().isOk(),
+        true);
+  }
+
+  /**
+   * Tests a conflicting request to add a new SSP Implemented Requirement via POST.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testImplAlreadyExistsViaPost() throws Exception {
+
+    testSspImplReq(
+        HttpMethod.POST,
+        EXISTING_IMPL_REQ_UUID,
+        EXISTING_CONTROL_ID,
+        EXISTING_STATEMENT_ID,
+        EXISTING_COMPONENT_UUID,
+        EXISTING_PARAM_ID,
+        EXPECTED_PARAM_VALUE,
+        status().isConflict(),
+        false);
+  }
+
+  /**
+   * Tests if the request to add a new SSP Implemented Requirement updates the SSP via PUT.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testCreateSspImplReqViaPut() throws Exception {
+    testSspImplReq(
+        HttpMethod.PUT,
+        NEW_IMPL_REQ_UUID,
+        NEW_CONTROL_ID,
+        NEW_STATEMENT_ID,
+        NEW_COMPONENT_UUID,
+        NEW_PARAM_ID,
+        EXPECTED_PARAM_VALUE,
+        status().isOk(),
+        true);
+  }
+
+  /**
+   * Tests if the request to update an existing SSP Implemented Requirement updates the SSP via PUT.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testUpdateExistingSspImplReq() throws Exception {
+    testSspImplReq(
+        HttpMethod.PUT,
+        EXISTING_IMPL_REQ_UUID,
+        EXISTING_CONTROL_ID,
+        EXISTING_STATEMENT_ID,
+        EXISTING_COMPONENT_UUID,
+        EXISTING_PARAM_ID,
+        EXPECTED_PARAM_VALUE,
+        status().isOk(),
+        true);
+  }
 }


### PR DESCRIPTION
- Created an `OscalSspImplReqMarshallerImpl`
- Updated `IterableAssemblyClassBinding` to define a list of
`secondaryRootObjects` that will 'trick' the deserializer to allow as
root objects
- Updated `BaseOscalObjectMarshallerLiboscalImpl` to be able to create
deserializer with `IterableAssemblyClassBinding`
- Updated `SspController` and tests

Closes #57
Closes #58