### PR TITLE
Only return the new implemented requirement

### DIFF
--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -179,8 +179,8 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
     }
 
     logger.debug("SSP ImplementedRequiremnt updated, saving via service");
-
-    return makeObjectResponse(oscalObjectService.save(existingSsp));
+    oscalObjectService.save(existingSsp);
+    return makeObjectResponse(incomingImplReq, oscalSspImplReqtMarshaller);
   }
 
   /**


### PR DESCRIPTION
Per the specification, we must return the _new_ implemented requirement
object; not the entire SSP. We can add somewhat more generic versions of
the existing `makeXxxResponse` methods for this use case (and we can
leave the old implementations as more convenient wrappers for the root
object types).
