### PR TITLE
Revert "Update to liboscal-java 1.0.4.1"

### DIFF
--- a/oscal-data-repository-commons-tests/pom.xml
+++ b/oscal-data-repository-commons-tests/pom.xml
@@ -29,7 +29,6 @@
 							<outputDirectory>${project.build.directory}/classes</outputDirectory>
 							<unpack>true</unpack>
 							<followRedirects>true</followRedirects>
-							<download.cache.skip>true</download.cache.skip>
 						</configuration>
 					</execution>
 				</executions>

--- a/oscal-data-repository-commons/pom.xml
+++ b/oscal-data-repository-commons/pom.xml
@@ -13,7 +13,7 @@
 	<description>Parent for OSCAL data repository implementations</description>
 
 	<properties>
-		<liboscal-java.version>1.0.4.1</liboscal-java.version>
+		<liboscal-java.version>1.0.2</liboscal-java.version>
 	</properties>
 
 	<dependencies>

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
@@ -5,9 +5,8 @@ import com.easydynamics.oscal.data.marshalling.IterableJsonSerializer;
 import com.easydynamics.oscal.data.marshalling.OscalObjectMarshaller;
 import com.easydynamics.oscal.data.marshalling.OscalObjectMarshallingException;
 import gov.nist.secauto.metaschema.binding.IBindingContext;
-import gov.nist.secauto.metaschema.binding.io.DeserializationFeature;
+import gov.nist.secauto.metaschema.binding.io.Feature;
 import gov.nist.secauto.metaschema.binding.io.IDeserializer;
-import gov.nist.secauto.metaschema.binding.io.SerializationFeature;
 import gov.nist.secauto.metaschema.binding.io.json.DefaultJsonDeserializer;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
 import java.io.IOException;
@@ -29,13 +28,13 @@ public abstract class BaseOscalObjectMarshallerLiboscalImpl<T> implements OscalO
    */
   public BaseOscalObjectMarshallerLiboscalImpl(Class<T> clazz) {
     super();
-    IBindingContext context = IBindingContext.instance();
+    IBindingContext context = IBindingContext.newInstance();
     IAssemblyClassBinding classBinding =
         IterableAssemblyClassBinding.createInstance(clazz, context);
     this.serializer = new IterableJsonSerializer<T>(context, classBinding);
-    this.serializer.enableFeature(SerializationFeature.SERIALIZE_ROOT);
+    this.serializer.enableFeature(Feature.SERIALIZE_ROOT);
     this.deserializer = new DefaultJsonDeserializer<T>(context, classBinding);
-    this.deserializer.enableFeature(DeserializationFeature.DESERIALIZE_JSON_ROOT_PROPERTY);
+    this.deserializer.enableFeature(Feature.DESERIALIZE_JSON_ROOT_PROPERTY);
   }
 
   @Override

--- a/oscal-data-repository-file/src/main/java/com/easydynamics/oscal/data/repository/file/BaseOscalRepoFileImpl.java
+++ b/oscal-data-repository-file/src/main/java/com/easydynamics/oscal/data/repository/file/BaseOscalRepoFileImpl.java
@@ -1,10 +1,10 @@
 package com.easydynamics.oscal.data.repository.file;
 
 import gov.nist.secauto.metaschema.binding.IBindingContext;
+import gov.nist.secauto.metaschema.binding.io.Feature;
 import gov.nist.secauto.metaschema.binding.io.Format;
 import gov.nist.secauto.metaschema.binding.io.IBoundLoader;
 import gov.nist.secauto.metaschema.binding.io.ISerializer;
-import gov.nist.secauto.metaschema.binding.io.SerializationFeature;
 import gov.nist.secauto.metaschema.binding.model.annotations.MetaschemaAssembly;
 import java.io.File;
 import java.io.IOException;
@@ -60,10 +60,10 @@ public abstract class BaseOscalRepoFileImpl<T extends Object>
     this.path = path;
     this.genericClass = genericClass;
     this.oscalRootName = getOscalRootName(genericClass);
-    IBindingContext bindingContext = IBindingContext.instance();
+    IBindingContext bindingContext = IBindingContext.newInstance();
     this.oscalLoader = bindingContext.newBoundLoader();
     this.serializer = bindingContext.newSerializer(Format.JSON, genericClass);
-    this.serializer.enableFeature(SerializationFeature.SERIALIZE_ROOT);
+    this.serializer.enableFeature(Feature.SERIALIZE_ROOT);
   }
 
   protected String getOscalRootName(Class<T> genericClass) {


### PR DESCRIPTION
Reverts EasyDynamics/oscal-rest-service#107

This version outputs a huge amount of log data that is difficult to parse. This will be fixed in the next version of `liboscal-java`, which will include `metaschema-java` v0.9.0 or newer. Further, it's unclear whether #111 is related to the 1.0.4.1 update; however, some initial testing does not show that it is reproducible on 1.0.2. 

For now, we will rollback, continue testing 1.0.4.1 on a separate branch, and open issues upstream as needed.