### PR TITLE
Add the triage workflow

### DIFF
--- a/.github/workflows/triage-pr.yml
+++ b/.github/workflows/triage-pr.yml
@@ -1,0 +1,93 @@
+---
+name: Triage pull request
+
+on:
+  pull_request_review:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+env:
+  DEFAULT_REVIEW_TEAM: "easygrc-reviewers"
+
+jobs:
+  assignReviewers:
+    # This job automatically continues to assign reviews to a pull request each time
+    # a pull request is (re)opened or a review is added/edited/dismissed until the
+    # review threshold has been met. This pauses requesting reviews when a reviwer
+    # has requested changes (and therefore, set the overall review state to
+    # CHANGES_REQUESTED). It will happily continue running once that review is
+    # dismissed or the reviewer changes their review to an approval. This matches
+    # the general expectations of our branch protection rules where all requested
+    # changes must be resolved before a PR can be merged.
+    name: Automatically assign reviewers
+    runs-on: ubuntu-latest
+    permissions:
+      # This job itself only needs to be able to read pull requests. We use a
+      # separate token to perform the actual review request.
+      pull-requests: read
+    steps:
+      - name: Get review status
+        id: pr-reviews
+        uses: actions/github-script@v6
+        with:
+          # Leverage the GraphQL API to determine whether the current review
+          # decision status. This is different from the `mergeable`-related statuses
+          # available directly on the event context as this purely factors in reviews,
+          # not status checks or other situations. Additionally, in many cases,
+          # the `mergeable`-related fields are null/"unknown" and so we'd have to query
+          # for them anyway.
+          # This query is performed with the basic pull-requests:read permissions on
+          # the overall `secrets.GITHUB_TOKEN` to limit the permissions. Notable, that
+          # means this cannot perform mutations or call non-PR APIs.
+          script: |
+            const query = `query($owner:String!, $name:String!, $number:Int!) {
+              repository(owner:$owner, name:$name) {
+                pullRequest(number:$number) {
+                  reviewDecision,
+                  isDraft
+                }
+              }
+            }`;
+            const variables = {
+              owner: context.repo.owner,
+              name: context.repo.repo,
+              number: context.payload.pull_request.number,
+            };
+            console.log(`Request variables: ${JSON.stringify(variables)}`);
+            const result = await github.graphql(query, variables);
+            const decision = result.repository.pullRequest.reviewDecision;
+            console.log(`Review Decision: ${decision}`);
+            core.setOutput("review-decision", decision);
+            core.setOutput("is-draft", result.repository.pullRequest.isDraft);
+      - name: Generate token from App
+        # Only authenticate as the application if a review is still required. If the review
+        # criteria have been met then there's not much point in requesting another review and
+        # it will just generate unnecessary noise. Additionally, we really want to use the
+        # app's elevated permissions as infrequently as possible.
+        if: steps.pr-reviews.outputs.is-draft == 'false' && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
+        id: generate_token
+        # This maps to v1.6.0 https://github.com/tibdex/github-app-token/releases/tag/v1.6.0
+        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          permissions: >-
+            {
+              "pull_requests": "write",
+              "members": "read"
+            }
+      - name: Assign reviewers
+        uses: actions/github-script@v6
+        if: steps.pr-reviews.outputs.is-draft == 'false' && steps.pr-reviews.outputs.review-decision == 'REVIEW_REQUIRED'
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              team_reviewers: ["${{ env.DEFAULT_REVIEW_TEAM }}"]
+            });


### PR DESCRIPTION
This adds a workflow to triage PRs and assign them to a default reviewer team.