### PR TITLE
Validate Component UUID on Save after Edit

### DIFF
--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/OscalSspByComponentMarshallerImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/OscalSspByComponentMarshallerImpl.java
@@ -1,0 +1,14 @@
+package com.easydynamics.oscal.data.marshalling.impl;
+
+import gov.nist.secauto.oscal.lib.model.ByComponent;
+
+/**
+ * OSCAL ByComponent marshaller implementation.
+ */
+public class OscalSspByComponentMarshallerImpl
+    extends BaseOscalObjectMarshallerLiboscalImpl<ByComponent> {
+
+  public OscalSspByComponentMarshallerImpl() {
+    super(ByComponent.class);
+  } 
+}

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/OscalSspStatementMarshallerImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/OscalSspStatementMarshallerImpl.java
@@ -1,0 +1,14 @@
+package com.easydynamics.oscal.data.marshalling.impl;
+
+import gov.nist.secauto.oscal.lib.model.Statement;
+
+/**
+ * OSCAL Statement marshaller implementation.
+ */
+public class OscalSspStatementMarshallerImpl
+    extends BaseOscalObjectMarshallerLiboscalImpl<Statement> {
+
+  public OscalSspStatementMarshallerImpl() {
+    super(Statement.class);
+  } 
+}

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/ServiceConfig.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/ServiceConfig.java
@@ -4,12 +4,16 @@ import com.easydynamics.oscal.data.marshalling.OscalObjectMarshaller;
 import com.easydynamics.oscal.data.marshalling.impl.OscalCatalogMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalComponentMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalProfileMarshallerImpl;
+import com.easydynamics.oscal.data.marshalling.impl.OscalSspByComponentMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalSspImplReqMarshallerImpl;
 import com.easydynamics.oscal.data.marshalling.impl.OscalSspMarshallerImpl;
+import com.easydynamics.oscal.data.marshalling.impl.OscalSspStatementMarshallerImpl;
+import gov.nist.secauto.oscal.lib.model.ByComponent;
 import gov.nist.secauto.oscal.lib.model.Catalog;
 import gov.nist.secauto.oscal.lib.model.ComponentDefinition;
 import gov.nist.secauto.oscal.lib.model.ImplementedRequirement;
 import gov.nist.secauto.oscal.lib.model.Profile;
+import gov.nist.secauto.oscal.lib.model.Statement;
 import gov.nist.secauto.oscal.lib.model.SystemSecurityPlan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -45,5 +49,15 @@ public class ServiceConfig {
   @Bean
   public OscalObjectMarshaller<ImplementedRequirement> sspImplReqMarshaller() {
     return new OscalSspImplReqMarshallerImpl();
+  }
+
+  @Bean
+  public OscalObjectMarshaller<Statement> sspStatementMarshaller() {
+    return new OscalSspStatementMarshallerImpl();
+  }
+
+  @Bean
+  public OscalObjectMarshaller<ByComponent> sspByComponentMarshaller() {
+    return new OscalSspByComponentMarshallerImpl();
   }
 }

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -178,23 +178,22 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
         unmarshallImplReqAndValidateId(implementedRequirementId, json);
 
     // Find existing ImplementedRequirement if exists and merge or add
-    ImplementedRequirement existingImplReq = null;
+    Optional<ImplementedRequirement> existingImplReq = Optional.empty();
     if (existingSsp.getControlImplementation() != null
         && existingSsp.getControlImplementation().getImplementedRequirements() != null) {
       existingImplReq =
           existingSsp.getControlImplementation().getImplementedRequirements().stream()
           .filter(implReq -> incomingImplReq.getUuid().equals(implReq.getUuid()))
-          .findAny()
-          .orElse(null);
+          .findAny();
     }
-    if (existingImplReq == null) {
+    if (!existingImplReq.isPresent()) {
       addImplReqToList(existingSsp, incomingImplReq);
     } else {
       try {
-        OscalDeepCopyUtils.deepCopyProperties(existingImplReq, incomingImplReq);
+        OscalDeepCopyUtils.deepCopyProperties(existingImplReq.get(), incomingImplReq);
       } catch (IllegalAccessException | InvocationTargetException e) {
         throw new InvalidDataAccessResourceUsageException(
-            "could not deep copy object", e);
+            "Could not deep copy object", e);
       }
     }
 
@@ -340,7 +339,7 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
         .findAny();
 
     // Find existing Statement if exists and merge or add
-    Statement existingStmt = null;
+    Optional<Statement> existingStmt = Optional.empty();
     if (existingSsp.getControlImplementation() != null
         && existingSsp.getControlImplementation().getImplementedRequirements() != null
         && existingImplReq != null
@@ -348,17 +347,16 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
             .anyMatch(implReq -> existingImplReq.get().getUuid().equals(implReq.getUuid()))) {
       existingStmt = existingImplReq.get().getStatements().stream()
           .filter(stmt -> incomingStmt.getUuid().equals(stmt.getUuid()))
-          .findAny()
-          .orElse(null);
+          .findAny();
     }
-    if (existingStmt == null) {
+    if (!existingStmt.isPresent()) {
       addStatementToList(existingImplReq.get(), incomingStmt);
     } else {
       try {
-        OscalDeepCopyUtils.deepCopyProperties(existingStmt, incomingStmt);
+        OscalDeepCopyUtils.deepCopyProperties(existingStmt.get(), incomingStmt);
       } catch (IllegalAccessException | InvocationTargetException e) {
         throw new InvalidDataAccessResourceUsageException(
-            "could not deep copy object", e);
+            "Could not deep copy object", e);
       }
     }
 
@@ -545,7 +543,7 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
         .findAny();
 
     // Find existing ByComponent if exists and merge or add
-    ByComponent existingByComp = null;
+    Optional<ByComponent> existingByComp = Optional.empty();
     if (existingSsp.getControlImplementation() != null
         && existingSsp.getControlImplementation().getImplementedRequirements() != null
         && existingImplReq != null
@@ -555,17 +553,16 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
             .anyMatch(stmt -> existingStmt.get().getUuid().equals(stmt.getUuid()))) {
       existingByComp = existingStmt.get().getByComponents().stream()
           .filter(byComp -> incomingByComp.getUuid().equals(byComp.getUuid()))
-          .findAny()
-          .orElse(null);
+          .findAny();
     }
-    if (existingByComp == null) {
+    if (!existingByComp.isPresent()) {
       addComponentToList(existingStmt.get(), incomingByComp);
     } else {
       try {
-        OscalDeepCopyUtils.deepCopyProperties(existingByComp, incomingByComp);
+        OscalDeepCopyUtils.deepCopyProperties(existingByComp.get(), incomingByComp);
       } catch (IllegalAccessException | InvocationTargetException e) {
         throw new InvalidDataAccessResourceUsageException(
-            "could not deep copy object", e);
+            "Could not deep copy object", e);
       }
     }
 

--- a/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
+++ b/oscal-rest-service-app/src/main/java/com/easydynamics/oscalrestservice/api/SspController.java
@@ -591,6 +591,10 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
         implementedRequirementId);
     Optional<Statement> existingStmt = getSspStatement(existingImplReq.get(), statementId);
 
+    if (incomingByComp.getComponentUuid() != null) {
+      throw new OscalObjectConflictException("No Component Uuid provided");
+    }
+    
     // Find existing ByComponent if exists and merge or add
     Optional<ByComponent> existingByComp = Optional.empty();
     if (existingSsp.getControlImplementation() != null
@@ -664,6 +668,9 @@ public class SspController extends BaseOscalController<SystemSecurityPlan> {
     ByComponent incomingByComp = oscalSspByComponentMarshaller.toObject(
         new ByteArrayInputStream(json.getBytes()));
 
+    if (incomingByComp.getComponentUuid() != null) {
+      throw new OscalObjectConflictException("No Component Uuid provided");
+    }
     // Throw an exception if statement already exists
     if (existingSsp.getControlImplementation().getImplementedRequirements() != null
         && existingSsp.getControlImplementation().getImplementedRequirements() != null


### PR DESCRIPTION
When running OSCAL Editor and attempting to save changes to numbered control statements occurring with a decimal (eg. AC-1.2) when in an SSP model example, the results wouldn't be saved. This is a result of the `by-component`'s `component-uuid` is not being set. In order to fix this change, the endpoints for a `statement` and `by-component` needed to be implemented for an SSP in the REST service.

To handle saving the `component-uuid`, `statements` and `by-components` were implemented in a similar fashion to `implemented requirements` in the ssp. This involved setting up marshallers for both extending `BaseOscalObjectMarshallerLiboscalIml` and creating beans in the apps `ServiceConfig`. Several helper methods assist with updating/adding `statements` or `by-components` which are saved in lists underneath their respective hierarchically property.

Closes #100