### PR TITLE
chore(deps): bump spring-core and spring-test to 6.0.5

### DIFF
--- a/oscal-data-repository-commons/pom.xml
+++ b/oscal-data-repository-commons/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-			<version>${spring-core.version}</version>
+			<version>${spring.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/oscal-data-repository-file/pom.xml
+++ b/oscal-data-repository-file/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
-			<version>${spring-test.version}</version>
+			<version>${spring.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/oscal-object-service/pom.xml
+++ b/oscal-object-service/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
-			<version>${spring-test.version}</version>
+			<version>${spring.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
 		<java.version>17</java.version>
 		<validation-api.version>2.0.1.Final</validation-api.version>
 		<spring-boot-starter-data-jpa.version>3.0.2</spring-boot-starter-data-jpa.version>
-		<spring-core.version>6.0.5</spring-core.version>
-		<spring-test.version>${spring-core.version}</spring-test.version>
+		<spring.version>6.0.5</spring.version>
 		<junit.version>5.9.2</junit.version>
 		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 		<java.version>17</java.version>
 		<validation-api.version>2.0.1.Final</validation-api.version>
 		<spring-boot-starter-data-jpa.version>3.0.2</spring-boot-starter-data-jpa.version>
-		<spring-core.version>6.0.4</spring-core.version>
-		<spring-test.version>6.0.4</spring-test.version>
+		<spring-core.version>6.0.5</spring-core.version>
+		<spring-test.version>${spring-core.version}</spring-test.version>
 		<junit.version>5.9.2</junit.version>
 		<maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>


### PR DESCRIPTION
This handles updating both spring-core and
spring-test in one PR. As far as it seems
spring-core and spring-test have consistently
follow the same version in maven, so
spring-test has been made to reference
spring-core in attempt to avoid
multiple merge requests.