### PR TITLE
fix(workflows): publish worklflows fails to delete old versions

### DIFF
--- a/.github/workflows/gh-packages.yml
+++ b/.github/workflows/gh-packages.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     steps:
       - name: Delete previous oscal-rest-service version
-        uses: actions/delete-package-versions@v4
+        uses: actions/delete-package-versions@v3.0.1
         with:
           package-name: com.easydynamics.oscal-rest-service-app
           package-type: maven


### PR DESCRIPTION
Upgrading to v4 of the delete-package-versions action caused
the workflow to fail. #171 tracks upgrading at a later date.
