### PR TITLE
feat(commons): add a "no-op" constraint validation handler

### DIFF
--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/constraint/NoopConstraintValidationHandler.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/constraint/NoopConstraintValidationHandler.java
@@ -21,7 +21,7 @@ import java.util.List;
  * is taken. This allows for very quiet runs of the service against noisy documents to
  * focus on actual errors and messages from the surrounding tooling.
  */
-public class NullConstraintValidationHandler implements IConstraintValidationHandler {
+public class NoopConstraintValidationHandler implements IConstraintValidationHandler {
   @Override
   public void handleAllowedValuesViolation(List<IAllowedValuesConstraint> arg0, INodeItem arg1) {
     return;

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/constraint/NullConstraintValidationHandler.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/constraint/NullConstraintValidationHandler.java
@@ -1,0 +1,87 @@
+package com.easydynamics.oscal.data.constraint;
+
+import gov.nist.secauto.metaschema.model.common.constraint.IAllowedValuesConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.ICardinalityConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.IConstraintValidationHandler;
+import gov.nist.secauto.metaschema.model.common.constraint.IExpectConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.IIndexConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.IIndexHasKeyConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.IKeyConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.IMatchesConstraint;
+import gov.nist.secauto.metaschema.model.common.constraint.IUniqueConstraint;
+import gov.nist.secauto.metaschema.model.common.metapath.DynamicContext;
+import gov.nist.secauto.metaschema.model.common.metapath.ISequence;
+import gov.nist.secauto.metaschema.model.common.metapath.MetapathException;
+import gov.nist.secauto.metaschema.model.common.metapath.item.INodeItem;
+import java.util.List;
+
+/**
+ * A constraint validation handler that does nothing with errors. When any of the `handle`
+ * methods for this validation handler are invoked, no action
+ * is taken. This allows for very quiet runs of the service against noisy documents to
+ * focus on actual errors and messages from the surrounding tooling.
+ */
+public class NullConstraintValidationHandler implements IConstraintValidationHandler {
+  @Override
+  public void handleAllowedValuesViolation(List<IAllowedValuesConstraint> arg0, INodeItem arg1) {
+    return;
+  }
+
+  @Override
+  public void handleCardinalityMaximumViolation(ICardinalityConstraint arg0, INodeItem arg1,
+      ISequence<? extends INodeItem> arg2) {
+    return;
+  }
+
+  @Override
+  public void handleCardinalityMinimumViolation(ICardinalityConstraint arg0, INodeItem arg1,
+      ISequence<? extends INodeItem> arg2) {
+    return;
+  }
+
+  @Override
+  public void handleExpectViolation(IExpectConstraint arg0, INodeItem arg1, INodeItem arg2,
+      DynamicContext arg3) {
+    return;
+  }
+
+  @Override
+  public void handleIndexDuplicateKeyViolation(IIndexConstraint arg0, INodeItem arg1,
+      INodeItem arg2, INodeItem arg3) {
+    return;
+  }
+
+  @Override
+  public void handleIndexDuplicateViolation(IIndexConstraint arg0, INodeItem arg1) {
+    return;
+  }
+
+  @Override
+  public void handleIndexMiss(IIndexHasKeyConstraint arg0, INodeItem arg1, INodeItem arg2) {
+    return;
+  }
+
+  @Override
+  public void handleKeyMatchError(IKeyConstraint arg0, INodeItem arg1, INodeItem arg2,
+      MetapathException arg3) {
+    return;
+  }
+
+  @Override
+  public void handleMatchDatatypeViolation(IMatchesConstraint arg0, INodeItem arg1,
+      INodeItem arg2, String arg3, IllegalArgumentException arg4) {
+    return;
+  }
+
+  @Override
+  public void handleMatchPatternViolation(IMatchesConstraint arg0, INodeItem arg1, INodeItem arg2,
+      String arg3) {
+    return;
+  }
+
+  @Override
+  public void handleUniqueKeyViolation(IUniqueConstraint arg0, INodeItem arg1, INodeItem arg2,
+      INodeItem arg3) {
+    return;
+  }
+}

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
@@ -1,5 +1,6 @@
 package com.easydynamics.oscal.data.marshalling.impl;
 
+import com.easydynamics.oscal.data.constraint.NullConstraintValidationHandler;
 import com.easydynamics.oscal.data.marshalling.IterableAssemblyClassBinding;
 import com.easydynamics.oscal.data.marshalling.IterableJsonSerializer;
 import com.easydynamics.oscal.data.marshalling.OscalObjectMarshaller;
@@ -38,6 +39,7 @@ public abstract class BaseOscalObjectMarshallerLiboscalImpl<T> implements OscalO
     this.serializer.enableFeature(SerializationFeature.SERIALIZE_ROOT);
     this.deserializer = new DefaultJsonDeserializer<T>(context, classBinding);
     this.deserializer.enableFeature(DeserializationFeature.DESERIALIZE_JSON_ROOT_PROPERTY);
+    this.deserializer.setConstraintValidationHandler(new NullConstraintValidationHandler());
   }
 
   @Override

--- a/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
+++ b/oscal-data-repository-commons/src/main/java/com/easydynamics/oscal/data/marshalling/impl/BaseOscalObjectMarshallerLiboscalImpl.java
@@ -1,16 +1,17 @@
 package com.easydynamics.oscal.data.marshalling.impl;
 
-import com.easydynamics.oscal.data.constraint.NullConstraintValidationHandler;
+import com.easydynamics.oscal.data.constraint.NoopConstraintValidationHandler;
 import com.easydynamics.oscal.data.marshalling.IterableAssemblyClassBinding;
 import com.easydynamics.oscal.data.marshalling.IterableJsonSerializer;
 import com.easydynamics.oscal.data.marshalling.OscalObjectMarshaller;
 import com.easydynamics.oscal.data.marshalling.OscalObjectMarshallingException;
-import gov.nist.secauto.metaschema.binding.IBindingContext;
 import gov.nist.secauto.metaschema.binding.io.DeserializationFeature;
+import gov.nist.secauto.metaschema.binding.io.Format;
+import gov.nist.secauto.metaschema.binding.io.IBoundLoader;
 import gov.nist.secauto.metaschema.binding.io.IDeserializer;
-import gov.nist.secauto.metaschema.binding.io.SerializationFeature;
 import gov.nist.secauto.metaschema.binding.io.json.DefaultJsonDeserializer;
 import gov.nist.secauto.metaschema.binding.model.IAssemblyClassBinding;
+import gov.nist.secauto.oscal.lib.OscalBindingContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,14 +33,13 @@ public abstract class BaseOscalObjectMarshallerLiboscalImpl<T> implements OscalO
    */
   public BaseOscalObjectMarshallerLiboscalImpl(Class<T> clazz) {
     super();
-    IBindingContext context = IBindingContext.instance();
-    IAssemblyClassBinding classBinding = 
+    OscalBindingContext context = OscalBindingContext.instance();
+    IAssemblyClassBinding classBinding =
         IterableAssemblyClassBinding.createInstance(clazz, context);
+
     this.serializer = new IterableJsonSerializer<T>(context, classBinding);
-    this.serializer.enableFeature(SerializationFeature.SERIALIZE_ROOT);
     this.deserializer = new DefaultJsonDeserializer<T>(context, classBinding);
-    this.deserializer.enableFeature(DeserializationFeature.DESERIALIZE_JSON_ROOT_PROPERTY);
-    this.deserializer.setConstraintValidationHandler(new NullConstraintValidationHandler());
+    this.deserializer.setConstraintValidationHandler(new NoopConstraintValidationHandler());
   }
 
   @Override


### PR DESCRIPTION
This is an attempt to use the `IConstraintValidationHandler` plumbing in
liboscal-java to have a handler that does nothing at all. This hopefully fixes
some issues that we are having where logging (which is the default handler) is
in the hot path and the response doesn't get returned until the logs are emitted.
And for some reason, there are a lot of validation failures so these logs take
quite awhile to be written. This should significantly cut down the amount of time
it takes to return a response to the `GET /catalogs` and `GET /catalogs/{uuid}`
endpoints.

If this isn't fast enough, we can just (temporarily) disable constraint validation
until we can see what's up with these duplicate key constraint violations.