### PR TITLE
chore(pipeline): add Java 20 to test matrix

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -18,8 +18,8 @@ jobs:
           # all LTSes can target themselves and the oldest supported LTS, and that the latest
           # stable release can target itself. We do not test against EA builds.
           - { actual: 17, target: 17 } # Latest LTS
-          - { actual: 18, target: 18 } # Latest stable release
           - { actual: 19, target: 19 } # Latest stable release
+          - { actual: 20, target: 20 } # Latest stable release
     runs-on: ubuntu-latest
     name: "Build and test on Java ${{ matrix.java.actual }} targeting ${{ matrix.java.target }}"
     steps:


### PR DESCRIPTION
Java 20 is expected some time within the next month. We need to remember
to add this to our testing matrix in the pipeline. Technically, we claim
to only test the "latest" stable release, but we'll go ahead and
continue testing two (we need Java 17 for LTS still anyway).

This needs to not be merged until Java 20 is GA. It is currently in the
RC phase. It is expected on March 21.
